### PR TITLE
added sts4-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ tmp/
 local.properties
 .loadpath
 .factorypath
+.sts4-cache/
 
 ##############################
 ## NetBeans


### PR DESCRIPTION
Spring Tool Suite (Eclipse-Ableger) erzeugt einen eigenen sts4-cache folder. Den hab ich in .gitignore zugefügt